### PR TITLE
Fix use of invalid constant for window focus state

### DIFF
--- a/focus.py
+++ b/focus.py
@@ -141,7 +141,7 @@ class FocusModeListener(sublime_plugin.EventListener):
             enter_view_focus_mode(view)
 
     def on_new_window(self, window: sublime.Window):
-        if window.template_settings().has(FOCUS_STATE_KEY):
+        if window.template_settings().has(FOCUS_MODE_KEY):
             exit_focus_mode(window)
 
     def on_load(self, view: sublime.View):


### PR DESCRIPTION
The `FOCUS_STATE_KEY` constant was renamed to `FOCUS_MODE_KEY` during the last refactor, however it was not applied to the `on_new_window` event listener method.